### PR TITLE
Add support for data in GET requests

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -4,9 +4,10 @@
  */
 
 const logger = require('./logger'),
-  querystring = require('querystring'),
   oAuth = require('oauth-1.0a'),
   request = require('request');
+
+const version = require('../package.json').version;
 
 class Request {
 
@@ -29,29 +30,18 @@ class Request {
     });
   }
 
-  requestData(path, method) {
+  requestData(path, method, data) {
     return {
       url: `${this.options.hostname}${path}`,
       method: method,
-      data: {}
+      data: data || {}
     };
-  }
-
-  formatQuery(authorize) {
-    let query = '?';
-    for (let key in authorize) {
-      const val = key === 'oauth_signature' ?
-        querystring.escape(authorize[key]) : authorize[key];
-      query += key + '=' + val + '&';
-    }
-    return query.substr(0, query.length - 1);
   }
 
   getOAuthParams(options) {
     const oauth = this.oAuthConfig();
-    const req = this.requestData(options.path, options.method);
-    const authorize = oauth.authorize(req);
-    return this.formatQuery(authorize);
+    const req = this.requestData(options.path, options.method, options.data);
+    return oauth.authorize(req);
   }
 
   error(message, response, body, error) {
@@ -71,24 +61,33 @@ class Request {
       const options = {
         method,
         url: fullPath,
+        qs: {},
         headers: {
-          'User-Agent': 'node-woocommerce/2.0.0',
+          'User-Agent': `node-woocommerce/${version}`,
           'Accept': 'application/json, *.*'
         }
       };
 
-      if (data) options.json = data;
+      if (data) {
+        if (method === 'get') options.qs = data;
+        else options.json = data;
+      }
+
       if (this.options.ssl) {
         logger.info('Using basic auth');
         options.auth = {
           user: this.options.consumerKey,
           pass: this.options.secret
         };
-        options.url += `?consumer_key=${this.options.consumerKey}` +
-          `&consumer_secret=${this.options.secret}`;
+        options.qs.consumer_key = this.options.consumerKey;
+        options.qs.consumer_secret = this.options.secret;
       } else {
-        const oAuthParams = this.getOAuthParams({ path: apiPath, method });
-        options.url += oAuthParams;
+        const oAuthParams = this.getOAuthParams({
+          method,
+          path: apiPath,
+          data: options.qs
+        });
+        options.qs = oAuthParams;
       }
 
       request(options, (err, response, body) => {

--- a/lib/woocommerce.js
+++ b/lib/woocommerce.js
@@ -55,8 +55,12 @@ class WooCommerce {
     return this.options.apiPath + path;
   }
 
-  get(path, cb) {
-    return this.request.complete('get', this.fullPath(path), null, cb);
+  get(path, data, cb) {
+    if (typeof data === 'function') {
+      cb = data;
+      data = null;
+    }
+    return this.request.complete('get', this.fullPath(path), data, cb);
   }
 
   post(path, data, cb) {

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   },
   "homepage": "https://github.com/Receiptful/node-woocommerce",
   "devDependencies": {
-    "chai": "^2.3.0",
-    "istanbul": "^0.3.13",
-    "mocha": "^2.2.4",
-    "nock": "^0.57.0",
-    "sinon": "^1.14.1"
+    "chai": "^3.5.0",
+    "istanbul": "^0.4.2",
+    "mocha": "^2.4.5",
+    "nock": "^7.2.2",
+    "sinon": "^1.17.3"
   },
   "dependencies": {
     "oauth-1.0a": "^1.0.1",
-    "request": "^2.67.0"
+    "request": "^2.69.0"
   }
 }

--- a/test/woocommerce.js
+++ b/test/woocommerce.js
@@ -253,10 +253,30 @@ describe('Request: #WooCommerce', () => {
     });
   });
 
+  it('Should support data for GET requests', done => {
+    const api = nock('https://foo.com/')
+      .get('/orders')
+      .query({
+        consumer_key: 'foo',
+        consumer_secret: 'foo',
+        filter: {
+          limit: 10
+        }
+      })
+      .reply(200, '{ "success": true }');
+
+    rBasic.complete('get', '/orders', { 'filter[limit]': 10 }, (err, data) => {
+      should.not.exist(err);
+      data.should.be.a.string;
+      api.done();
+      done();
+    });
+  });
+
   it('Should return content for https using Basic Auth', done => {
     const api = nock('https://foo.com/')
-      .filteringPath(/\?.*/g, '?xxx')
-      .post('/orders?xxx', {})
+      .post('/orders')
+      .query(true)
       .reply(200, '{ "success": true }');
 
     rBasic.complete('post', '/orders', {}, (err, data) => {


### PR DESCRIPTION
This commit adds support for supplying a data argument to GET
requests which is turned into a query string when fetching the resource.

Changes:
- Add data argument to get function.
- Simplify oauth parameter generation.
- Updates node dependencies

Also manually tested this change on local WooCommerce installation with and without https and with and without query parameters.
