### PR TITLE
Trim the body string for JSON parse

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -120,18 +120,17 @@ class Request {
 
           var json = {};
           if (typeof body === 'string' && body.trim() !== '') {
-            json = JSON.parse(body);
+            json = JSON.parse(body.trim());
           } else if (typeof body === 'object') {
             json = body;
           }
 
-          if (json.hasOwnProperty('error') ||
-            json.hasOwnProperty('errors')) {
-              const errorMessage = json.error || JSON.stringify(json.errors);
-              const serverError = this.error(errorMessage, response, body);
-              cb(serverError, body, response);
-              reject(serverError);
-              return;
+          if (json.hasOwnProperty('error') || json.hasOwnProperty('errors')) {
+            const errorMessage = json.error || JSON.stringify(json.errors);
+            const serverError = this.error(errorMessage, response, body);
+            cb(serverError, body, response);
+            reject(serverError);
+            return;
           }
 
           logger.info('Request complete, returning data and response.');


### PR DESCRIPTION
This will trim any whitespace from the response. Currently if there is a space before the json starts it errors.
