### PR TITLE
Add support for new wp-json API

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const logger = require('./logger'),
-  oAuth = require('oauth-1.0a'),
-  request = require('request');
+const crypto = require('crypto'),
+  OAuth = require('oauth-1.0a'),
+  request = require('request'),
+  logger = require('./logger');
 
 const version = require('../package.json').version;
 
@@ -17,14 +18,18 @@ class Request {
   }
 
   oAuthConfig() {
-    return oAuth({
+    return new OAuth({
       consumer: {
-        public: this.options.consumerKey,
+        key: this.options.consumerKey,
         secret: this.options.secret
       },
       signature_method: 'HMAC-SHA256',
-      version: null,
-      last_ampersand: false
+      hash_function: (baseString, key) => {
+        return crypto.createHmac('sha256', key)
+          .update(baseString)
+          .digest('base64');
+      },
+      last_ampersand: !this.options.legacy
     });
   }
 

--- a/lib/woocommerce.js
+++ b/lib/woocommerce.js
@@ -33,6 +33,7 @@ class WooCommerce {
     // Set defaults
     this.options.logLevel = this.options.logLevel || 0;
     this.options.apiPath = this.options.apiPath || '/wc-api/v2';
+    this.options.legacy = !this.options.apiPath.includes('wp-json');
 
     // Automatically set ssl when not set
     this.options.ssl = this.options.ssl || /https/.test(options.url);
@@ -47,7 +48,8 @@ class WooCommerce {
       consumerKey: this.options.consumerKey,
       secret: this.options.secret,
       logLevel: this.options.logLevel,
-      timeout: this.options.timeout
+      timeout: this.options.timeout,
+      legacy: this.options.legacy
     });
 
     logger.info(util.inspect(this.options));

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "sinon": "^1.17.3"
   },
   "dependencies": {
-    "oauth-1.0a": "^1.0.1",
+    "oauth-1.0a": "^2.0.0",
     "request": "^2.69.0"
   }
 }

--- a/test/woocommerce.js
+++ b/test/woocommerce.js
@@ -39,6 +39,7 @@ describe('WooCommerce', () => {
       wc.options.logLevel.should.equal(0);
       wc.options.ssl.should.equal(false);
       wc.options.apiPath.should.equal('/wc-api/v2');
+      wc.options.legacy.should.equal(true);
     });
 
     it('Should set the correct ssl default for https', () => {
@@ -59,6 +60,17 @@ describe('WooCommerce', () => {
       });
 
       wc.options.ssl.should.equal(false);
+    });
+
+    it('should set legacy to false for new api', () => {
+      const wc = new WooCommerce({
+        url: 'http://foo.com',
+        consumerKey: 'foo',
+        secret: 'foo',
+        apiPath: '/wp-json/wc/v1'
+      });
+
+      wc.options.legacy.should.equal(false);
     });
   });
 


### PR DESCRIPTION
This commit adds support for the new wp-json API. The oauth parameters
work in slightly different ways between the new and old API.

Related to #15 

It's been tested against a local WooCommerce installation. This is a bit difficult to build into the unit tests though. Here's a little script that will show it working in both cases:

```
'use strict';

const WC = require('./lib/woocommerce');

const wc1 = new WC({
  url: 'http://woocommerce.dev',
  ssl: false,
  consumerKey: 'somekey',
  secret: 'somesecret',
});

const wc2 = new WC({
  url: 'http://woocommerce.dev',
  ssl: false,
  consumerKey: 'somekey',
  secret: 'somesecret',
  apiPath: '/wp-json/wc/v1'
});

wc1.get('/products').then(p => console.log(p.products.length)).catch(console.error);
wc2.get('/products').then(p => console.log(p.length)).catch(console.error);
```

Before this PR, the `wc2` call would fail.
